### PR TITLE
Data type of cardinality needs to be string.

### DIFF
--- a/data/field/fields.yaml
+++ b/data/field/fields.yaml
@@ -1,4 +1,4 @@
-cardinality: n
+cardinality: 'n'
 datatype: string
 field: fields
 phase: alpha

--- a/data/field/food-premises-types.yaml
+++ b/data/field/food-premises-types.yaml
@@ -1,4 +1,4 @@
-cardinality: n
+cardinality: 'n'
 datatype: string
 field: food-premises-types
 phase: alpha

--- a/data/field/parent-bodies.yaml
+++ b/data/field/parent-bodies.yaml
@@ -1,4 +1,4 @@
-cardinality: n
+cardinality: 'n'
 datatype: string
 field: parent-bodies
 phase: alpha


### PR DESCRIPTION
[YAML considers unquoted 'y' and 'n' as boolean values](http://yaml.org/type/bool.html). We've defined cardinality as strings, but haven't quoted the 'n' portion, causing the loader to fail validation when parsing these entries.
