### PR TITLE
Restore missing newlines to copyright data

### DIFF
--- a/data/register/address.yaml
+++ b/data/register/address.yaml
@@ -1,5 +1,5 @@
-copyright: "Contains Ordnance Survey data \xA9 Crown copyright & database right 2015
-Contains Royal Mail data \xA9 Royal Mail copyright & database right 2015"
+copyright: "Contains Ordnance Survey data \xA9 Crown copyright & database right 2015\n
+Contains Royal Mail data \xA9 Royal Mail copyright & database right 2015\n"
 fields:
 - address
 - property

--- a/data/register/postcode.yaml
+++ b/data/register/postcode.yaml
@@ -1,5 +1,5 @@
-copyright: "Contains National Statistics data © [Crown copyright and database right 2013](http://www.nationalarchives.gov.uk/doc/open-government-licence/),
-Contains Ordnance Survey data © [Crown copyright and database right 2013](http://www.ordnancesurvey.co.uk/oswebsite/docs/licences/os-opendata-licence.pdf),
+copyright: "Contains National Statistics data © [Crown copyright and database right 2013](http://www.nationalarchives.gov.uk/doc/open-government-licence/),\n
+Contains Ordnance Survey data © [Crown copyright and database right 2013](http://www.ordnancesurvey.co.uk/oswebsite/docs/licences/os-opendata-licence.pdf),\n
 Contains Royal Mail data © [Royal Mail copyright and database right 2013](http://www.dfpni.gov.uk/lps/index/copyright_licensing_publishing.htm)"
 fields:
 - postcode


### PR DESCRIPTION
These were inadvertantly removed in 98fc5837 and d074a23c82b3.