### PR TITLE
Local authority discovery

### DIFF
--- a/data/discovery/datatype/datetime.yaml
+++ b/data/discovery/datatype/datetime.yaml
@@ -1,0 +1,6 @@
+datatype: datetime
+phase: beta
+text: A combination of a date and a time in the format `CCYY-MM-DDThh:mm:ss[Z]` as described
+    in chapter 5.4 of [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601).
+    The value can be truncated to just the most significant digits, for example "2014-05".
+    Time values, where present, should be in UTC.

--- a/data/discovery/datatype/string.yaml
+++ b/data/discovery/datatype/string.yaml
@@ -1,0 +1,4 @@
+datatype: string
+phase: beta
+text: A string of [Unicode 6.2.x](http://www.unicode.org/versions/Unicode6.2.0/)
+    characters encoded as [UTF-8](http://en.wikipedia.org/wiki/UTF-8).

--- a/data/discovery/datatype/text.yaml
+++ b/data/discovery/datatype/text.yaml
@@ -1,0 +1,4 @@
+datatype: text
+phase: beta
+text: A string of text which may contain [Markdown](http://en.wikipedia.org/wiki/Markdown)
+   formatting instructions.

--- a/data/discovery/field/cardinality.yaml
+++ b/data/discovery/field/cardinality.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: cardinality
+phase: beta
+register: ''
+text: Number of elements of the set (1 or n).

--- a/data/discovery/field/copyright.yaml
+++ b/data/discovery/field/copyright.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: text
+field: copyright
+phase: beta
+register: ''
+text: Copyright for the data in the register.

--- a/data/discovery/field/datatype.yaml
+++ b/data/discovery/field/datatype.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: datatype
+phase: alpha
+register: datatype
+text: The data type for constraining a field value.

--- a/data/discovery/field/end-date.yaml
+++ b/data/discovery/field/end-date.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: datetime
+field: end-date
+phase: beta
+register: ''
+text: End datetime for the applicability of a register entry.

--- a/data/discovery/field/field.yaml
+++ b/data/discovery/field/field.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: field
+phase: alpha
+register: field
+text: Field name of register entry.

--- a/data/discovery/field/fields.yaml
+++ b/data/discovery/field/fields.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: string
+field: fields
+phase: beta
+register: field
+text: Set of field names.

--- a/data/discovery/field/local-authority-type.yaml
+++ b/data/discovery/field/local-authority-type.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: local-authority-type
+phase: discovery
+register: local-authority-type
+text: 'The type of a local government organisation in the United Kingdom.'

--- a/data/discovery/field/local-authority.yaml
+++ b/data/discovery/field/local-authority.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: local-authority
+phase: discovery
+register: local-authority
+text: 'A local government organisation in the United Kingdom.'

--- a/data/discovery/field/name-cy.yaml
+++ b/data/discovery/field/name-cy.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: name-cy
+phase: discovery
+register: ''
+text: Welsh name for an entry

--- a/data/discovery/field/name.yaml
+++ b/data/discovery/field/name.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: name
+phase: beta
+register: ''
+text: English name for an entry

--- a/data/discovery/field/official-name.yaml
+++ b/data/discovery/field/official-name.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: official-name
+phase: beta
+register: ''
+text: Official name for an entry

--- a/data/discovery/field/parent-local-authority.yaml
+++ b/data/discovery/field/parent-local-authority.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: parent-local-authority
+phase: discovery
+register: local-authority
+text: 'An upper-tier or other local government organisation having responsibilities for a local authority.'

--- a/data/discovery/field/phase.yaml
+++ b/data/discovery/field/phase.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: phase
+phase: beta
+register: ''
+text: Phase of a register or service as defined by the [digital service manual](https://www.gov.uk/service-manual).

--- a/data/discovery/field/register.yaml
+++ b/data/discovery/field/register.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: register
+phase: beta
+register: register
+text: A register name.

--- a/data/discovery/field/registry.yaml
+++ b/data/discovery/field/registry.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: registry
+phase: beta
+register: ''
+text: 'Body responsible for maintaining one or more registers'

--- a/data/discovery/field/start-date.yaml
+++ b/data/discovery/field/start-date.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: datetime
+field: start-date
+phase: beta
+register: ''
+text: Start datetime for the applicability of a register entry.

--- a/data/discovery/field/text.yaml
+++ b/data/discovery/field/text.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: text
+field: text
+phase: beta
+register: ''
+text: Description of register entry.

--- a/data/discovery/field/uk.yaml
+++ b/data/discovery/field/uk.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: uk
+phase: discovery
+register: uk
+text: A constituent unit of the United Kingdom

--- a/data/discovery/field/website.yaml
+++ b/data/discovery/field/website.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: website
+phase: discovery
+text: 'The website for an organisation.'
+register:

--- a/data/discovery/register/datatype.yaml
+++ b/data/discovery/register/datatype.yaml
@@ -1,0 +1,8 @@
+fields:
+- datatype
+- phase
+- text
+phase: alpha
+register: datatype
+registry: cabinet-office
+text: 'Datatypes constraining values used by register fields and idenitifying ways in which it may be encoded a representation'

--- a/data/discovery/register/field.yaml
+++ b/data/discovery/register/field.yaml
@@ -1,0 +1,11 @@
+fields:
+- field
+- datatype
+- phase
+- register
+- cardinality
+- text
+phase: alpha
+register: field
+registry: cabinet-office
+text: 'Field names which may appear in a register'

--- a/data/discovery/register/local-authority-type.yaml
+++ b/data/discovery/register/local-authority-type.yaml
@@ -1,0 +1,9 @@
+fields:
+- local-authority-type
+- name
+- start-date
+- end-date
+phase: discovery
+register: local-authority-type
+registry: cabinet-office
+text: 'Types of local government organisations in the United Kingdom'

--- a/data/discovery/register/local-authority.yaml
+++ b/data/discovery/register/local-authority.yaml
@@ -1,5 +1,6 @@
 fields:
 - local-authority
+- uk
 - parent-local-authority
 - local-authority-type
 - name

--- a/data/discovery/register/local-authority.yaml
+++ b/data/discovery/register/local-authority.yaml
@@ -1,0 +1,14 @@
+fields:
+- local-authority
+- parent-local-authority
+- local-authority-type
+- name
+- name-cy
+- official-name
+- website
+- start-date
+- end-date
+phase: discovery
+register: local-authority
+registry: cabinet-office
+text: 'Local government organisations in the United Kingdom'

--- a/data/discovery/register/register.yaml
+++ b/data/discovery/register/register.yaml
@@ -1,0 +1,11 @@
+fields:
+- register
+- text
+- registry
+- phase
+- copyright
+- fields
+phase: beta
+register: register
+registry: cabinet-office
+text: 'Registers maintained by HM Government'

--- a/data/discovery/register/uk.yaml
+++ b/data/discovery/register/uk.yaml
@@ -1,0 +1,10 @@
+fields:
+- uk
+- name
+- official-name
+- start-date
+- end-date
+phase: discovery
+register: uk
+registry: cabinet-office
+text: 'Constituent units of the United Kingdom'

--- a/data/discovery/registry/cabinet-office.yaml
+++ b/data/discovery/registry/cabinet-office.yaml
@@ -1,0 +1,1 @@
+registry: cabinet-office


### PR DESCRIPTION
Created a new 'discovery' phase for the local-authority and local-authority-type
registers - see the local-authority-data repo for seed data and documentation.

Note: this repo could do with a refactor as copying and cloning has made it even
less easy to maintain. 

Maybe we could look at making the 'phase' field allow us to cite
registers across directories rather than having to copy them into each phase
directory.