### PR TITLE
Add school-authority register and related field config to discovery

### DIFF
--- a/data/discovery/datatype/curie.yaml
+++ b/data/discovery/datatype/curie.yaml
@@ -1,0 +1,6 @@
+datatype: curie
+phase: discovery
+text: A [CURIE](http://en.wikipedia.org/wiki/CURIE) defines a generic abbreviated
+    syntax for expressing Uniform Resource Identifiers (URIs). e.g. [company:012345],
+    [public-body:cabinet-office]. Relative values link to the register identified in
+    the entry for the field in the field register.

--- a/data/discovery/field/organisation.yaml
+++ b/data/discovery/field/organisation.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: curie
+field: organisation
+phase: discovery
+register:
+text: A legal entity.

--- a/data/discovery/field/school-authority.yaml
+++ b/data/discovery/field/school-authority.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-authority
+phase: discovery
+register: school-authority
+text: 'School authority organisation.'

--- a/data/discovery/register/school-authority.yaml
+++ b/data/discovery/register/school-authority.yaml
@@ -1,0 +1,8 @@
+fields:
+- school-authority
+- name
+- organisation
+phase: discovery
+register: school-authority
+registry: department-for-education
+text: 'School authority organisation'

--- a/data/discovery/register/school.yaml
+++ b/data/discovery/register/school.yaml
@@ -2,7 +2,7 @@ fields:
 - school
 - name
 - address
-- local-authority
+- school-authority
 - minimum-age
 - maximum-age
 - headteacher


### PR DESCRIPTION
* Add `school-authority` register and related field configuration.
* Change school `local-authority` field to `school-authority`.
* The text descriptions are provisional, and subject to change.