### PR TITLE
Add alpha register/field config for school registers

### DIFF
--- a/data/alpha/datatype/integer.yaml
+++ b/data/alpha/datatype/integer.yaml
@@ -1,5 +1,5 @@
 datatype: integer
-phase: discovery
+phase: alpha
 text: Integer number, conforming to the XML Schema 2.0
     [xs:integer](http://www.w3.org/TR/xmlschema-2/#integer) definition,
     represented in canonical form.

--- a/data/alpha/datatype/integer.yaml
+++ b/data/alpha/datatype/integer.yaml
@@ -1,0 +1,5 @@
+datatype: integer
+phase: discovery
+text: Integer number, conforming to the XML Schema 2.0
+    [xs:integer](http://www.w3.org/TR/xmlschema-2/#integer) definition,
+    represented in canonical form.

--- a/data/alpha/field/address.yaml
+++ b/data/alpha/field/address.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: address
+phase: discovery
+register: ''
+text: 'An address in the UK.'

--- a/data/alpha/field/address.yaml
+++ b/data/alpha/field/address.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
 field: address
-phase: discovery
+phase: alpha
 register: ''
 text: 'An address in the UK.'

--- a/data/alpha/field/diocese.yaml
+++ b/data/alpha/field/diocese.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: diocese
+phase: alpha
+register: diocese
+text: 'A district under the pastoral care of a bishop in the Christian Church.'

--- a/data/alpha/field/dioceses.yaml
+++ b/data/alpha/field/dioceses.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: string
+field: dioceses
+phase: alpha
+register: diocese
+text: 'A list of districts under the pastoral care of a bishop in the Christian Church.'

--- a/data/alpha/field/maximum-age.yaml
+++ b/data/alpha/field/maximum-age.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: integer
+field: maximum-age
+phase: alpha
+register: ''
+text: Maximum age.

--- a/data/alpha/field/minimum-age.yaml
+++ b/data/alpha/field/minimum-age.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: integer
+field: minimum-age
+phase: alpha
+register: ''
+text: Minimum age.

--- a/data/alpha/field/organisation.yaml
+++ b/data/alpha/field/organisation.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: organisation
+phase: alpha
+register: ''
+text: A legal entity.

--- a/data/alpha/field/religious-character.yaml
+++ b/data/alpha/field/religious-character.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: religious-character
+phase: alpha
+register: religious-character
+text: 'A religion or subgroup within a religion operating under a common name, tradition, and identity.'

--- a/data/alpha/field/religious-characters.yaml
+++ b/data/alpha/field/religious-characters.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: string
+field: religious-characters
+phase: alpha
+register: religious-character
+text: 'A list of religion or subgroup within a religion operating under a common name, tradition, and identity.'

--- a/data/alpha/field/school-admissions-policy.yaml
+++ b/data/alpha/field/school-admissions-policy.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-admissions-policy
+phase: alpha
+register: school-admissions-policy
+text: 'The admissions policy for a school.'

--- a/data/alpha/field/school-authority.yaml
+++ b/data/alpha/field/school-authority.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-authority
+phase: alpha
+register: school-authority
+text: 'School authority organisation.'

--- a/data/alpha/field/school-eng.yaml
+++ b/data/alpha/field/school-eng.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-eng
+phase: alpha
+register: school-eng
+text: 'School in England legally registered to provide full time education to pupils of compulsory school age.'

--- a/data/alpha/field/school-gender.yaml
+++ b/data/alpha/field/school-gender.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-gender
+phase: alpha
+register: school-gender
+text: 'The gender of a school.'

--- a/data/alpha/field/school-phase.yaml
+++ b/data/alpha/field/school-phase.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-phase
+phase: alpha
+register: school-phase
+text: 'Phase of a school.'

--- a/data/alpha/field/school-tag.yaml
+++ b/data/alpha/field/school-tag.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-tag
+phase: alpha
+register: school-tag
+text: 'Tag which may be applied to a school.'

--- a/data/alpha/field/school-tags.yaml
+++ b/data/alpha/field/school-tags.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: string
+field: school-tags
+phase: alpha
+register: school-tag
+text: 'Set of tags which may be applied to a school.'

--- a/data/alpha/field/school-trust.yaml
+++ b/data/alpha/field/school-trust.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
-field: school-type
+field: school-trust
 phase: alpha
 register: school-trust
 text: 'Trust running a school.'

--- a/data/alpha/field/school-trust.yaml
+++ b/data/alpha/field/school-trust.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-type
+phase: alpha
+register: school-trust
+text: 'Trust running a school.'

--- a/data/alpha/field/school-type.yaml
+++ b/data/alpha/field/school-type.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-type
+phase: alpha
+register: school-type
+text: 'Type of a school.'

--- a/data/alpha/register/diocese.yaml
+++ b/data/alpha/register/diocese.yaml
@@ -1,0 +1,10 @@
+fields:
+- diocese
+- name
+- religious-character
+- start-date
+- end-date
+phase: alpha
+register: diocese
+registry: department-for-education
+text: 'Districts under the pastoral care of a bishop in the Christian Church'

--- a/data/alpha/register/religious-character.yaml
+++ b/data/alpha/register/religious-character.yaml
@@ -1,0 +1,9 @@
+fields:
+- religious-character
+- name
+- start-date
+- end-date
+phase: alpha
+register: religious-character
+registry: department-for-education
+text: 'A religion or subgroup within a religion operating under a common name, tradition, and identity'

--- a/data/alpha/register/school-admissions-policy.yaml
+++ b/data/alpha/register/school-admissions-policy.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-admissions-policy
+- name
+- start-date
+- end-date
+phase: alpha
+register: school-admissions-policy
+registry: department-for-education
+text: 'School admissions policies'

--- a/data/alpha/register/school-authority.yaml
+++ b/data/alpha/register/school-authority.yaml
@@ -1,0 +1,8 @@
+fields:
+- school-authority
+- name
+- organisation
+phase: alpha
+register: school-authority
+registry: department-for-education
+text: 'School authority organisation'

--- a/data/alpha/register/school-eng.yaml
+++ b/data/alpha/register/school-eng.yaml
@@ -1,0 +1,21 @@
+fields:
+- school-eng
+- name
+- address
+- school-authority
+- minimum-age
+- maximum-age
+- religious-characters
+- dioceses
+- school-type
+- school-phase
+- school-admissions-policy
+- school-gender
+- school-tags
+- school-trust
+- start-date
+- end-date
+phase: alpha
+register: school-eng
+registry: department-for-education
+text: 'Schools in England legally registered to provide full time education to pupils of compulsory school age'

--- a/data/alpha/register/school-gender.yaml
+++ b/data/alpha/register/school-gender.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-gender
+- name
+- start-date
+- end-date
+phase: alpha
+register: school-gender
+registry: department-for-education
+text: 'The gender of a school'

--- a/data/alpha/register/school-phase.yaml
+++ b/data/alpha/register/school-phase.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-phase
+- name
+- start-date
+- end-date
+phase: alpha
+register: school-phase
+registry: department-for-education
+text: 'The phase of a school'

--- a/data/alpha/register/school-tag.yaml
+++ b/data/alpha/register/school-tag.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-tag
+- text
+- start-date
+- end-date
+phase: alpha
+register: school-tag
+registry: department-for-education
+text: 'Tags which may be applied to a school'

--- a/data/alpha/register/school-trust.yaml
+++ b/data/alpha/register/school-trust.yaml
@@ -1,0 +1,10 @@
+fields:
+- school-trust
+- name
+- organisation
+- start-date
+- end-date
+phase: alpha
+register: school-trust
+registry: department-for-education
+text: 'Trusts running schools'

--- a/data/alpha/register/school-type.yaml
+++ b/data/alpha/register/school-type.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-type
+- name
+- start-date
+- end-date
+phase: alpha
+register: school-type
+registry: department-for-education
+text: 'Types of schools'

--- a/data/alpha/registry/department-for-education.yaml
+++ b/data/alpha/registry/department-for-education.yaml
@@ -1,0 +1,1 @@
+registry: department-for-education


### PR DESCRIPTION
Add configuration for England school register and associated registers and fields.

Configure alpha `address` field to be a string datatype without a register - as the address registers are not being moved to alpha.

Configure alpha `organisation` field to be a string datatype. We intend organisation to have a curie datatype. We are going to set organisation curie's that point to company records, and the company register is not in alpha.