### PR TITLE
Add school-trust-join-date field to alpha school-eng register

### DIFF
--- a/data/alpha/field/school-trust-join-date.yaml
+++ b/data/alpha/field/school-trust-join-date.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: datetime
+field: school-trust-join-date
+phase: alpha
+register: ''
+text: 'Date school joins school trust.'

--- a/data/alpha/register/school-eng.yaml
+++ b/data/alpha/register/school-eng.yaml
@@ -13,6 +13,7 @@ fields:
 - school-gender
 - school-tags
 - school-trust
+- school-trust-join-date
 - school-umbrella-trust
 - start-date
 - end-date


### PR DESCRIPTION
Add `school-trust-join-date` field to capture date when school joins a school trust.