### PR TITLE
Add name-change-date field to discovery company register

### DIFF
--- a/data/discovery/field/name-change-date.yaml
+++ b/data/discovery/field/name-change-date.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: datetime
+field: name-change-date
+phase: discovery
+register: ''
+text: Start datetime for the applicability of a change to name field value.

--- a/data/discovery/register/company.yaml
+++ b/data/discovery/register/company.yaml
@@ -5,6 +5,7 @@ fields:
 - address
 - industry
 - start-date
+- name-change-date
 - end-date
 phase: discovery
 register: company


### PR DESCRIPTION
Add `name-change-date` field to capture date on which a company name change occurs.