### PR TITLE
Add jobcentre register

### DIFF
--- a/data/discovery/field/jobcentre.yaml
+++ b/data/discovery/field/jobcentre.yaml
@@ -1,0 +1,6 @@
+text: "A job centre"
+field: "jobcentre"
+phase: "discovery"
+datatype: "string"
+register: "jobcentre"
+cardinality: "1"

--- a/data/discovery/register/jobcentre.yaml
+++ b/data/discovery/register/jobcentre.yaml
@@ -1,0 +1,9 @@
+fields:
+- "jobcentre"
+- "name"
+- "address"
+- "postcode"
+phase: "discovery"
+register: "jobcentre"
+registry: "department-for-work-pensions"
+text: "Job Centre Offices"


### PR DESCRIPTION
We are renaming "job-centre" to "jobcentre". The old name needs to hang
around until we've configured appropriate redirects.