### PR TITLE
Add academy and local-authority-maintained schools registers

### DIFF
--- a/data/alpha/field/academy-school-eng.yaml
+++ b/data/alpha/field/academy-school-eng.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: academy-school-eng
+phase: alpha
+register: academy-school-eng
+text: 'Academy school in England legally registered to provide full time education to pupils of compulsory school age.'

--- a/data/alpha/field/academy-sponsor.yaml
+++ b/data/alpha/field/academy-sponsor.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: academy-sponsor
+phase: alpha
+register: ''
+text: 'Academy sponsor'

--- a/data/alpha/field/academy-trust.yaml
+++ b/data/alpha/field/academy-trust.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: academy-trust
+phase: alpha
+register: ''
+text: 'Trust running an academy school.'

--- a/data/alpha/field/foundation-trust.yaml
+++ b/data/alpha/field/foundation-trust.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: foundation-trust
+phase: alpha
+register: ''
+text: 'Foundation trust'

--- a/data/alpha/field/la-maintained-school-eng.yaml
+++ b/data/alpha/field/la-maintained-school-eng.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: la-maintained-school-eng
+phase: alpha
+register: la-maintained-school-eng
+text: 'Local-authority-maintained school in England legally registered to provide full time education to pupils of compulsory school age.'

--- a/data/alpha/field/school-federation.yaml
+++ b/data/alpha/field/school-federation.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-federation
+phase: alpha
+register: ''
+text: 'School federation'

--- a/data/alpha/field/school-trust-join-date.yaml
+++ b/data/alpha/field/school-trust-join-date.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: datetime
+field: school-trust-join-date
+phase: alpha
+register: ''
+text: 'Date school joins school trust.'

--- a/data/alpha/register/academy-school-eng.yaml
+++ b/data/alpha/register/academy-school-eng.yaml
@@ -1,0 +1,10 @@
+fields:
+- academy-school-eng
+- school-type
+- academy-trust
+- school-trust-join-date
+- academy-sponsor
+phase: alpha
+register: academy-school-eng
+registry: department-for-education
+text: 'Academy schools in England legally registered to provide full time education to pupils of compulsory school age'

--- a/data/alpha/register/la-maintained-school-eng.yaml
+++ b/data/alpha/register/la-maintained-school-eng.yaml
@@ -1,0 +1,9 @@
+fields:
+- la-maintained-school-eng
+- school-type
+- foundation-trust
+- school-federation
+phase: alpha
+register: la-maintained-school-eng
+registry: department-for-education
+text: 'Local-authority-maintained schools in England legally registered to provide full time education to pupils of compulsory school age'

--- a/data/alpha/register/school-eng.yaml
+++ b/data/alpha/register/school-eng.yaml
@@ -9,7 +9,7 @@ fields:
 - religious-characters
 - religious-ethos
 - dioceses
-- school-type
+- organisation
 - school-phases
 - school-admissions-policy
 - school-gender


### PR DESCRIPTION
- Add `la-maintained-school-eng` register and related fields.
- Add `academy-school-eng` register and related fields.
- Replace `school-type` with `organisation` field in `school-eng` register.