### PR TITLE
Update address register to use correct fields (from Discovery)

### DIFF
--- a/data/test/datatype/point.yaml
+++ b/data/test/datatype/point.yaml
@@ -1,0 +1,9 @@
+datatype: point
+phase: discovery
+text: A longitude and latitude pair of coordinates, encoded as a string
+    representation of the GeoJSON point coordinates format. The values are
+    [Decimal Degrees](http://en.wikipedia.org/wiki/Decimal_degrees) in the
+    [ETRS89](https://en.wikipedia.org/wiki/European_Terrestrial_Reference_System_1989)
+    coordinate system for European locations and the largely compatible
+    [WGS84](http://spatialreference.org/ref/epsg/wgs-84/) coordinate system for
+    worldwide locations.

--- a/data/test/field/address.yaml
+++ b/data/test/field/address.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
 field: address
-phase: alpha
-register: address
+phase: discovery
+register: 
 text: A place in the UK with a postal address.

--- a/data/test/field/area.yaml
+++ b/data/test/field/area.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: area
-phase: alpha
-register: ''
-text: The administrative area of an address.

--- a/data/test/field/country.yaml
+++ b/data/test/field/country.yaml
@@ -2,5 +2,5 @@ cardinality: '1'
 datatype: string
 field: country
 phase: beta
-register: country
-text: ISO 3166-2 two letter code for a country.
+register: 
+text: The country's 2-letter ISO 3166-2 alpha2 code.

--- a/data/test/field/latitude.yaml
+++ b/data/test/field/latitude.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: latitude
-phase: alpha
-register: ''
-text: Latitude of a place.

--- a/data/test/field/locality.yaml
+++ b/data/test/field/locality.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: locality
-phase: alpha
-register: ''
-text: The area within a post town.

--- a/data/test/field/longitude.yaml
+++ b/data/test/field/longitude.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: longitude
-phase: alpha
-register:
-text: Longitude of a place.

--- a/data/test/field/name-cy.yaml
+++ b/data/test/field/name-cy.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: name-cy
+phase: discovery
+register: ''
+text: Welsh name for an entry

--- a/data/test/field/name-gd.yaml
+++ b/data/test/field/name-gd.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: name-gd
+phase: discovery
+register: ''
+text: Gaelic name for an entry

--- a/data/test/field/parent-address.yaml
+++ b/data/test/field/parent-address.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: parent-address
+phase: discovery
+register: address
+text: 'An address containing an address'

--- a/data/test/field/point.yaml
+++ b/data/test/field/point.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: point
+field: point
+phase: discovery
+register: ''
+text: 'A geographical location'

--- a/data/test/field/postcode.yaml
+++ b/data/test/field/postcode.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: postcode
-phase: alpha
-register:
-text: UK Postcodes.

--- a/data/test/field/primary-address.yaml
+++ b/data/test/field/primary-address.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: primary-address
+phase: discovery
+register: address
+text: 'An address which is the primary address for an address'

--- a/data/test/field/property.yaml
+++ b/data/test/field/property.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: property
-phase: alpha
-register: ''
-text: A building, institution or house name in an address.

--- a/data/test/field/street-custodian.yaml
+++ b/data/test/field/street-custodian.yaml
@@ -1,0 +1,6 @@
+text: "Local land and property gazetteer custodian"
+field: "street-custodian"
+phase: "discovery"
+datatype: "string"
+register: ""
+cardinality: "1"

--- a/data/test/field/town.yaml
+++ b/data/test/field/town.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: town
-phase: alpha
-register: ''
-text: The town of an address.

--- a/data/test/register/address.yaml
+++ b/data/test/register/address.yaml
@@ -2,16 +2,17 @@ copyright: "Contains Ordnance Survey data \xA9 Crown copyright & database right 
 Contains Royal Mail data \xA9 Royal Mail copyright & database right 2015\n"
 fields:
 - address
-- property
+- parent-address
+- primary-address
+- name
+- name-cy
+- name-gd
 - street
-- locality
-- town
-- area
-- postcode
-- country
-- latitude
-- longitude
-phase: alpha
+- street-custodian
+- point
+- start-date
+- end-date
+phase: discovery
 register: address
-registry: office-for-national-statistics
-text: 'Postal addresses in the UK'
+registry: cabinet-office
+text: 'Addresses in the UK'

--- a/data/test/register/country.yaml
+++ b/data/test/register/country.yaml
@@ -5,7 +5,7 @@ fields:
 - citizen-names
 - start-date
 - end-date
-phase: beta
+phase: discovery
 register: country
 registry: foreign-commonwealth-office
 text: 'British English-language names and descriptive terms for countries'

--- a/data/test/register/datatype.yaml
+++ b/data/test/register/datatype.yaml
@@ -2,7 +2,7 @@ fields:
 - datatype
 - phase
 - text
-phase: alpha
+phase: discovery
 register: datatype
 registry: cabinet-office
 text: 'Datatypes constraining values used by register fields and idenitifying ways in which it may be encoded a representation'

--- a/data/test/register/field.yaml
+++ b/data/test/register/field.yaml
@@ -5,7 +5,7 @@ fields:
 - register
 - cardinality
 - text
-phase: alpha
+phase: discovery
 register: field
 registry: cabinet-office
 text: 'Field names which may appear in a register'

--- a/data/test/register/register.yaml
+++ b/data/test/register/register.yaml
@@ -5,7 +5,7 @@ fields:
 - phase
 - copyright
 - fields
-phase: beta
+phase: discovery
 register: register
 registry: cabinet-office
 text: 'Registers maintained by HM Government'

--- a/data/test/registry/office-for-national-statistics.yaml
+++ b/data/test/registry/office-for-national-statistics.yaml
@@ -1,1 +1,0 @@
-registry: office-for-national-statistics


### PR DESCRIPTION
This PR updates `test` environment to use the `address` register setup - as defined in `discovery`. It also adds and removes fields in `test` in an effort to maintain a clean list of what is needed and being used.