### PR TITLE
Add name-cy field to discovery registration-district

### DIFF
--- a/data/discovery/register/registration-district.yaml
+++ b/data/discovery/register/registration-district.yaml
@@ -1,6 +1,7 @@
 fields:
 - registration-district
 - name
+- name-cy
 - local-authority
 - start-date
 - end-date


### PR DESCRIPTION
Add field to allow Welsh name to be added to a registration district entry.