### PR TITLE
Remove local-authority field from registration-district register

### DIFF
--- a/data/alpha/field/local-authority.yaml
+++ b/data/alpha/field/local-authority.yaml
@@ -1,6 +1,0 @@
-text: "A local authority in the United Kingdom."
-field: "local-authority"
-phase: "alpha"
-datatype: "curie"
-register: ""
-cardinality: "1"

--- a/data/alpha/register/registration-district.yaml
+++ b/data/alpha/register/registration-district.yaml
@@ -2,7 +2,6 @@ fields:
 - registration-district
 - name
 - name-cy
-- local-authority
 - start-date
 - end-date
 phase: alpha

--- a/data/discovery/field/local-authority.yaml
+++ b/data/discovery/field/local-authority.yaml
@@ -1,6 +1,0 @@
-text: "A local authority in the United Kingdom."
-field: "local-authority"
-phase: "discovery"
-datatype: "curie"
-register: ""
-cardinality: "1"

--- a/data/discovery/register/registration-district.yaml
+++ b/data/discovery/register/registration-district.yaml
@@ -2,7 +2,6 @@ fields:
 - registration-district
 - name
 - name-cy
-- local-authority
 - start-date
 - end-date
 phase: discovery


### PR DESCRIPTION
To prevent linking from alpha register to discovery Welsh local authority register.