### PR TITLE
Remove operator field from prison-estate alpha

### DIFF
--- a/data/alpha/datatype/curie.yaml
+++ b/data/alpha/datatype/curie.yaml
@@ -1,6 +1,0 @@
-datatype: curie
-phase: alpha
-text: A [CURIE](http://en.wikipedia.org/wiki/CURIE) defines a generic abbreviated
-    syntax for expressing Uniform Resource Identifiers (URIs). e.g. [company:012345],
-    [public-body:cabinet-office]. Relative values link to the register identified in
-    the entry for the field in the field register.

--- a/data/alpha/field/operator.yaml
+++ b/data/alpha/field/operator.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: curie
-field: operator
-phase: alpha
-register: ''
-text: An entity performing an operational role.

--- a/data/alpha/register/prison-estate.yaml
+++ b/data/alpha/register/prison-estate.yaml
@@ -1,7 +1,6 @@
 fields:
 - prison-estate
 - name
-- operator
 - start-date
 - end-date
 phase: alpha


### PR DESCRIPTION
Rich has agreed to remove the operator field.  Potentially we will encourage the custodian to put it back later when we have a better idea about companies.

Rejected alternatives were:
1. Leave it as a CURIE to the non-existent company register.  That's confusing.
2. Convert it to company names.  Not authoritative, not reversible.

See the parallel change in prison-estate-data https://github.com/openregister/prison-estate-data/pull/49.