### PR TITLE
Add fields to government-domain discovery

### DIFF
--- a/data/discovery/field/government-domain.yaml
+++ b/data/discovery/field/government-domain.yaml
@@ -1,6 +1,6 @@
-text: "A government domain"
-field: "government-domain"
-phase: "discovery"
-datatype: "string"
-register: "government-domain"
-cardinality: "1"
+cardinality: '1'
+datatype: string
+field: government-domain
+phase: discovery
+register: government-domain
+text: A government domain.

--- a/data/discovery/register/government-domain.yaml
+++ b/data/discovery/register/government-domain.yaml
@@ -1,6 +1,9 @@
 fields:
-- "government-domain"
-phase: "discovery"
-register: "government-domain"
-registry: "cabinet-office"
-text: "Government domains"
+- government-domain
+- organisation
+- start-date
+- end-date
+phase: discovery
+register: government-domain
+registry: cabinet-office
+text: 'Government domains'


### PR DESCRIPTION
The fields are now:

* government-domain
* organisation (curie)
* start-date
* end-date

Also the existing yaml has been modernised