### PR TITLE
Statistical-geography and statistical-geography-unitary-authority-wls alpha enviroments.

### DIFF
--- a/data/alpha/datatype/curie.yaml
+++ b/data/alpha/datatype/curie.yaml
@@ -1,0 +1,6 @@
+datatype: curie
+phase: alpha
+text: A [CURIE](http://en.wikipedia.org/wiki/CURIE) defines a generic abbreviated
+    syntax for expressing Uniform Resource Identifiers (URIs). e.g. [company:012345],
+    [public-body:cabinet-office]. Relative values link to the register identified in
+    the entry for the field in the field register.

--- a/data/alpha/field/area.yaml
+++ b/data/alpha/field/area.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: curie
+field: area
+phase: alpha
+register: ''
+text: The geographic area for an entity.

--- a/data/alpha/field/organisation.yaml
+++ b/data/alpha/field/organisation.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: curie
+field: organisation
+phase: alpha
+register: ''
+text: The entity's organisation.

--- a/data/alpha/field/statistical-geography-unitary-authority-wls.yaml
+++ b/data/alpha/field/statistical-geography-unitary-authority-wls.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: statistical-geography-unitary-authority-wls
+phase: alpha
+register: statistical-geography-unitary-authority-wls
+text: The statistical geography code for a principal local authority.

--- a/data/alpha/field/statistical-geography.yaml
+++ b/data/alpha/field/statistical-geography.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: statistical-geography
+phase: alpha
+register: statistical-geography
+text: The entity (record) for geographies that are used in official statistics.

--- a/data/alpha/register/statistical-geography-unitary-authority-wls.yaml
+++ b/data/alpha/register/statistical-geography-unitary-authority-wls.yaml
@@ -1,0 +1,9 @@
+fields:
+- statistical-geography-unitary-authority-wls
+- principal-local-authority
+- start-date
+- end-date
+phase: alpha
+register: statistical-geography-unitary-authority-wls
+registry: office-for-national-statistics
+text: Statistical geography data for principal local authorities in Wales

--- a/data/alpha/register/statistical-geography.yaml
+++ b/data/alpha/register/statistical-geography.yaml
@@ -1,0 +1,12 @@
+fields:
+- statistical-geography
+- name
+- area
+- organisation
+- register
+- start-date
+- end-date
+phase: alpha
+register: statistical-geography
+registry: office-for-national-statistics
+text: Geographies that are used in compiling official statistics

--- a/local/statistical-geography-unitary-authority-wls/custodian/Mike-Phelps-Cousins.yaml
+++ b/local/statistical-geography-unitary-authority-wls/custodian/Mike-Phelps-Cousins.yaml
@@ -1,0 +1,1 @@
+custodian: Mike Phelps-Cousins

--- a/local/statistical-geography/custodian/Mike-Phelps-Cousins.yaml
+++ b/local/statistical-geography/custodian/Mike-Phelps-Cousins.yaml
@@ -1,0 +1,1 @@
+custodian: Mike Phelps-Cousins

--- a/local/statistical-geography/field/name.yaml
+++ b/local/statistical-geography/field/name.yaml
@@ -1,0 +1,2 @@
+field: name
+text: The name of the entity.


### PR DESCRIPTION
What: two new alpha registers:
Statistical-geography
statistical-geography-unitary-authority-wls

When: this week if possible, latest Monday please

Dependencies: Duncan to approve the PR, platform team to make the environments

there are custom field descriptions