### PR TITLE
added data for reworked social-housing-provider register layout and two sub registers

### DIFF
--- a/data/alpha/field/social-housing-provider-designation.yaml
+++ b/data/alpha/field/social-housing-provider-designation.yaml
@@ -1,0 +1,6 @@
+field: social-housing-provider-designation
+phase: alpha
+datatype: string
+register: social-housing-provider-designation
+cardinality: "1"
+text: The possible designations for a social housing provider.

--- a/data/alpha/field/social-housing-provider-legal-entity.yaml
+++ b/data/alpha/field/social-housing-provider-legal-entity.yaml
@@ -1,0 +1,6 @@
+field: social-housing-provider-legal-entity
+phase: alpha
+datatype: string
+register: social-housing-provider-legal-entity
+cardinality: "1"
+text: The possible legal classifications for social housing providers.

--- a/data/alpha/register/social-housing-provider-designation.yaml
+++ b/data/alpha/register/social-housing-provider-designation.yaml
@@ -1,0 +1,9 @@
+fields:
+- social-housing-provider-designation
+- name
+- start-date
+- end-date
+phase: alpha
+register: social-housing-provider-designation
+registry: homes-and-communities-agency
+text: The Designation of a social housing provider

--- a/data/alpha/register/social-housing-provider-legal-entity.yaml
+++ b/data/alpha/register/social-housing-provider-legal-entity.yaml
@@ -1,0 +1,9 @@
+fields:
+- social-housing-provider-legal-entity
+- name
+- start-date
+- end-date
+phase: alpha
+register: social-housing-provider-legal-entity
+registry: homes-and-communities-agency
+text: The legal classification of the social housing provider

--- a/data/alpha/register/social-housing-provider.yaml
+++ b/data/alpha/register/social-housing-provider.yaml
@@ -1,6 +1,9 @@
 fields:
 - social-housing-provider
 - name
+- organisation
+- social-housing-provider-designation
+- social-housing-provider-legal-entity
 - start-date
 - end-date
 phase: alpha

--- a/local/social-housing-provider-designation/custodian/Julie-Bond.yaml
+++ b/local/social-housing-provider-designation/custodian/Julie-Bond.yaml
@@ -1,0 +1,1 @@
+custodian: Julie Bond

--- a/local/social-housing-provider-legal-entity/custodian/Julie-Bond.yaml
+++ b/local/social-housing-provider-legal-entity/custodian/Julie-Bond.yaml
@@ -1,0 +1,1 @@
+custodian: Julie Bond

--- a/local/social-housing-provider/custodian/Julie-Bond.yaml
+++ b/local/social-housing-provider/custodian/Julie-Bond.yaml
@@ -1,0 +1,1 @@
+custodian: Julie Bond


### PR DESCRIPTION
what: update to the social housing provider register requiring two new sub registers and a rework of the main register.

Who: Enda to check PR, platform to implement change

When: By end  of Tuesday