### PR TITLE
added files for an alpha government domain register

### DIFF
--- a/data/alpha/field/government-domain.yaml
+++ b/data/alpha/field/government-domain.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: government-domain
+phase: alpha
+register: government-domain
+text: A government domain.

--- a/data/alpha/field/hostname.yaml
+++ b/data/alpha/field/hostname.yaml
@@ -1,6 +1,6 @@
-cardinality: '1'
+cardinality: 1
 datatype: string
 field: hostname
 phase: alpha
-register: ''
+register: 
 text: The section of a URL that identifies a government domain.

--- a/data/alpha/field/hostname.yaml
+++ b/data/alpha/field/hostname.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: hostname
+phase: alpha
+register: ''
+text: The section of a URL that identifies a government domain.

--- a/data/alpha/field/hostname.yaml
+++ b/data/alpha/field/hostname.yaml
@@ -1,4 +1,4 @@
-cardinality: 1
+cardinality: '1'
 datatype: string
 field: hostname
 phase: alpha

--- a/data/alpha/register/government-domain.yaml
+++ b/data/alpha/register/government-domain.yaml
@@ -1,0 +1,10 @@
+fields:
+- government-domain
+- hostname
+- organisation
+- start-date
+- end-date
+phase: alpha
+register: government-domain
+registry: cabinet-office
+text: Government domains that appear on GOV.UK


### PR DESCRIPTION
What: government domains register into alpha

When, if possible today alongside the social housing provider updates

requirements: enda approve the pr, platform team implement.