### PR TITLE
Revert social-housing-provider-legal-entity cardinality change

### DIFF
--- a/data/alpha/field/social-housing-provider-legal-entity.yaml
+++ b/data/alpha/field/social-housing-provider-legal-entity.yaml
@@ -2,5 +2,5 @@ field: social-housing-provider-legal-entity
 phase: alpha
 datatype: string
 register: social-housing-provider-legal-entity
-cardinality: "n"
+cardinality: "1"
 text: The possible legal classifications for social housing providers.


### PR DESCRIPTION
This commit reverts the recent change to `social-housing-provider-legal-entity` which made the field cardinality `n`, instead changing it back to cardinality `1`. The reason for this change is because the field is the primary key of the `social-housing-provider-legal-entity` register, and so cannot be of cardinality `n`.

The reason this change was originally made was because the register `social-housing-provider` contains the field `social-housing-provider-legal-entity`, and in this register there can be many legal entities. The correct solution to this problem is to create a new field `social-housing-provider-legal-entities` of cardinality `n` and use this field instead.