### PR TITLE
Link public-body-classifications to public-body-classification

### DIFF
--- a/data/discovery/field/public-body-classifications.yaml
+++ b/data/discovery/field/public-body-classifications.yaml
@@ -2,5 +2,5 @@ cardinality: 'n'
 datatype: string
 field: public-body-classifications
 phase: discovery
-register:
+register: public-body-classification
 text: Classifications that a public body can have.


### PR DESCRIPTION
Use `"register":"public-body-classification"` to make the links work