### PR TITLE
Make organisation field cardinality=n and pluralize

### DIFF
--- a/data/discovery/field/organisation.yaml
+++ b/data/discovery/field/organisation.yaml
@@ -1,6 +1,6 @@
-cardinality: '1'
+cardinality: 'n'
 datatype: curie
-field: organisation
+field: organisations
 phase: discovery
 register: ''
 text: A legal entity.

--- a/data/discovery/field/organisations.yaml
+++ b/data/discovery/field/organisations.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: curie
-field: organisation
+field: organisations
 phase: discovery
 register: ''
-text: A legal entity.
+text: Legal entities.

--- a/data/discovery/register/public-body.yaml
+++ b/data/discovery/register/public-body.yaml
@@ -1,7 +1,7 @@
 fields:
 - public-body
 - name
-- organisation
+- organisations
 - public-body-classifications
 - start-date
 - end-date


### PR DESCRIPTION
Because public-body can be one:many e.g. Civil Nuclear
Police Authority (including Civil Nuclear Constabulary)