### PR TITLE
Change constituency custodian to Electoral Commission

### DIFF
--- a/data/discovery/register/westminster-parliamentary-constituency.yaml
+++ b/data/discovery/register/westminster-parliamentary-constituency.yaml
@@ -5,5 +5,5 @@ fields:
 - "end-date"
 phase: "discovery"
 register: "westminster-parliamentary-constituency"
-registry: "parliamentary-digital-service"
+registry: "the-electoral-commission"
 text: "Constituency in the Westminster parliament"

--- a/data/discovery/registry/parliamentary-digital-service.yaml
+++ b/data/discovery/registry/parliamentary-digital-service.yaml
@@ -1,1 +1,0 @@
-registry: parliamentary-digital-service

--- a/data/discovery/registry/the-electoral-commission.yaml
+++ b/data/discovery/registry/the-electoral-commission.yaml
@@ -1,0 +1,1 @@
+registry: the-electoral-commission


### PR DESCRIPTION
I don't think the Electoral Commission really would be the custodian (I think
it's the four boundary commissions), but it'll do until we find out for sure,
because it's on the Whitehall API and it's UK-wide, so we don't have to create
four separate registers until we know it's necessary.