### PR TITLE
Remove official-name field from local-authority-nir

### DIFF
--- a/data/discovery/register/local-authority-nir.yaml
+++ b/data/discovery/register/local-authority-nir.yaml
@@ -2,7 +2,6 @@ fields:
 - "local-authority-nir"
 - "local-authority-type"
 - "name"
-- "official-name"
 - "website"
 - "start-date"
 - "end-date"


### PR DESCRIPTION
Per custodian's advice that it's the same as the name field