### PR TITLE
Fix public-body phases to be alpha

### DIFF
--- a/data/alpha/field/public-body-classification.yaml
+++ b/data/alpha/field/public-body-classification.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
 field: public-body-classification
-phase: discovery
+phase: alpha
 register: public-body-classification
 text: A classification that a public body can have.

--- a/data/alpha/field/public-body.yaml
+++ b/data/alpha/field/public-body.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
 field: public-body
-phase: discovery
+phase: alpha
 register: public-body
 text: A current or former public body that is classified for national accounting.

--- a/data/alpha/register/public-body-classification.yaml
+++ b/data/alpha/register/public-body-classification.yaml
@@ -3,7 +3,7 @@ fields:
 - name
 - start-date
 - end-date
-phase: discovery
+phase: alpha
 register: public-body-classification
 registry: office-for-national-statistics
 text: 'A register of the classifications that current and former public bodies can have'

--- a/data/alpha/register/public-body.yaml
+++ b/data/alpha/register/public-body.yaml
@@ -5,7 +5,7 @@ fields:
 - public-body-classifications
 - start-date
 - end-date
-phase: discovery
+phase: alpha
 register: public-body
 registry: office-for-national-statistics
 text: 'A register of current and former public bodies that are classified for national accounting'


### PR DESCRIPTION
This wasn't detected by the tests, which turn out only to check
that the fields are in the same phase as the register, but not
that the register phases are correct.  Or something like that.