### PR TITLE
Add qualification-sub-level field to qualification-level register

### DIFF
--- a/data/discovery/field/parent-qualification-sector-subject-area.yaml
+++ b/data/discovery/field/parent-qualification-sector-subject-area.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
-field: qualification-subject
+field: parent-qualification-sector-subject-area
 phase: discovery
-register: qualification-subject
+register: qualification-sector-subject-area
 text: A subject of a qualification regulated by Ofqual

--- a/data/discovery/field/parent-qualification-sector-subject-area.yaml
+++ b/data/discovery/field/parent-qualification-sector-subject-area.yaml
@@ -3,4 +3,4 @@ datatype: string
 field: parent-qualification-sector-subject-area
 phase: discovery
 register: qualification-sector-subject-area
-text: A subject of a qualification regulated by Ofqual
+text: A broader subject area of a subject of a qualification regulated by Ofqual

--- a/data/discovery/field/qualification-sector-subject-area.yaml
+++ b/data/discovery/field/qualification-sector-subject-area.yaml
@@ -1,6 +1,6 @@
 cardinality: '1'
 datatype: string
-field: parent-qualification-subject
+field: qualification-sector-subject-area
 phase: discovery
-register: qualification-subject
+register: qualification-sector-subject-area
 text: A subject of a qualification regulated by Ofqual

--- a/data/discovery/field/qualification-sub-level.yaml
+++ b/data/discovery/field/qualification-sub-level.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: qualification-sub-level
+phase: discovery
+register:
+text: A sub-level of a qualification regulated by Ofqual

--- a/data/discovery/register/qualification-level.yaml
+++ b/data/discovery/register/qualification-level.yaml
@@ -1,6 +1,7 @@
 fields:
 - "qualification-level"
 - "name"
+- "qualification-sub-level"
 - "european-qualification-framework-level"
 - "start-date"
 - "end-date"

--- a/data/discovery/register/qualification-sector-subject-area.yaml
+++ b/data/discovery/register/qualification-sector-subject-area.yaml
@@ -1,10 +1,10 @@
 fields:
-- "qualification-subject"
-- "parent-qualification-subject"
+- "qualification-sector-subject-area"
+- "parent-qualification-sector-subject-area"
 - "name"
 - "start-date"
 - "end-date"
 phase: "discovery"
-register: "qualification-subject"
+register: "qualification-sector-subject-area"
 registry: "ofqual"
 text: "Subjects of qualifications regulated by Ofqual"


### PR DESCRIPTION
Agreed with custodian and tech arch.  Some misgivings about the fact that the
'name' field and the qualification-sub-level field are both names, but aren't
named the same, but it isn't worth normalising everything into a separate
qualification-sub-level register.