### PR TITLE
Create public-body-account registers in beta

### DIFF
--- a/data/beta/field/public-body-account-classification.yaml
+++ b/data/beta/field/public-body-account-classification.yaml
@@ -3,4 +3,4 @@ datatype: string
 field: public-body-account-classification
 phase: beta
 register: public-body-account-classification
-text: A national accounting classification that a public body can have.
+text: A national accounting classification that a public body can be assigned.

--- a/data/beta/field/public-body-account-classification.yaml
+++ b/data/beta/field/public-body-account-classification.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: public-body-account-classification
+phase: beta
+register: public-body-account-classification
+text: A national accounting classification that a public body can have.

--- a/data/beta/field/public-body-account-classifications.yaml
+++ b/data/beta/field/public-body-account-classifications.yaml
@@ -1,0 +1,6 @@
+cardinality: 'n'
+datatype: string
+field: public-body-account-classifications
+phase: beta
+register: public-body-account-classification
+text: National accounting classifications that a public body can have.

--- a/data/beta/field/public-body-account-classifications.yaml
+++ b/data/beta/field/public-body-account-classifications.yaml
@@ -3,4 +3,4 @@ datatype: string
 field: public-body-account-classifications
 phase: beta
 register: public-body-account-classification
-text: National accounting classifications that a public body can have.
+text: National accounting classifications that a public body can be assigned.

--- a/data/beta/field/public-body-account.yaml
+++ b/data/beta/field/public-body-account.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: public-body-account
+phase: beta
+register: public-body-account
+text: A current or former public body that is classified for national accounting.

--- a/data/beta/register/public-body-account-classification.yaml
+++ b/data/beta/register/public-body-account-classification.yaml
@@ -1,0 +1,9 @@
+fields:
+- public-body-account-classification
+- name
+- start-date
+- end-date
+phase: beta
+register: public-body-account-classification
+registry: office-for-national-statistics
+text: 'A register of the national accounting classifications that current and former public bodies can have'

--- a/data/beta/register/public-body-account-classification.yaml
+++ b/data/beta/register/public-body-account-classification.yaml
@@ -6,4 +6,4 @@ fields:
 phase: beta
 register: public-body-account-classification
 registry: office-for-national-statistics
-text: 'A register of the national accounting classifications that current and former public bodies can have'
+text: 'A register of the national accounting classifications that current and former public bodies can be assigned'

--- a/data/beta/register/public-body-account.yaml
+++ b/data/beta/register/public-body-account.yaml
@@ -1,0 +1,11 @@
+fields:
+- public-body-account
+- name
+- organisation
+- public-body-account-classifications
+- start-date
+- end-date
+phase: beta
+register: public-body-account
+registry: office-for-national-statistics
+text: 'A register of current and former public bodies that are classified for national accounting'


### PR DESCRIPTION
The field description of `organisation` should be customised (yet to be agreed) but that will be done in a separately from this.