### PR TITLE
Use generic 'parent' field.

### DIFF
--- a/data/discovery/field/parent-industrial-classification.yaml
+++ b/data/discovery/field/parent-industrial-classification.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: curie
-field: parent-industrial-classification
-phase: discovery
-register:
-text: 'The parent code in the hierarchy of Standard Industry Codes (SIC) used to classify business establishments and other standard units by the type of economic activity in which they are engaged.'

--- a/data/discovery/field/parent.yaml
+++ b/data/discovery/field/parent.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: curie
+field: parent
+phase: discovery
+register:
+text: 'The parent record in a hierarchy.'

--- a/data/discovery/register/industrial-classification-2003.yaml
+++ b/data/discovery/register/industrial-classification-2003.yaml
@@ -1,7 +1,7 @@
 fields:
 - industrial-classification-2003
 - name
-- parent-industrial-classification
+- parent
 - start-date
 - end-date
 phase: discovery

--- a/data/discovery/register/industrial-classification-2007.yaml
+++ b/data/discovery/register/industrial-classification-2007.yaml
@@ -1,7 +1,7 @@
 fields:
 - industrial-classification-2007
 - name
-- parent-industrial-classification
+- parent
 - start-date
 - end-date
 phase: discovery


### PR DESCRIPTION
Agreed with the technical architect, that hierarchies will be common, so it will
be better to define one generic 'parent' field as a CURIE, rather than lots of
parent fields that are register-specific.  Custom field descriptions will
explain to users what the field represents in each context.