### PR TITLE
Create fire-and-rescue-service in discovery

### DIFF
--- a/data/discovery/field/fire-and-rescue-service.yaml
+++ b/data/discovery/field/fire-and-rescue-service.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: fire-and-rescue-service
+phase: discovery
+register:
+text: A local fire and rescue service in the UK

--- a/data/discovery/register/fire-and-rescue-service.yaml
+++ b/data/discovery/register/fire-and-rescue-service.yaml
@@ -1,0 +1,10 @@
+fields:
+- fire-and-rescue-service
+- name
+- website
+- start-date
+- end-date
+phase: discovery
+register: fire-and-rescue-service
+registry: home-office
+text: A local fire and rescue service in the UK

--- a/data/discovery/registry/home-office.yaml
+++ b/data/discovery/registry/home-office.yaml
@@ -1,0 +1,1 @@
+registry: home-office


### PR DESCRIPTION
The home-office registry can be safely created without further work in
open-register-java because it already exists in this file
https://github.com/openregister/openregister-java/blob/master/src/main/resources/config/public-bodies.yaml