### PR TITLE
Be explicit about jobcentre countries

### DIFF
--- a/data/beta/register/jobcentre.yaml
+++ b/data/beta/register/jobcentre.yaml
@@ -9,4 +9,4 @@ fields:
 phase: beta
 register: jobcentre
 registry: department-for-work-pensions
-text: 'Jobcentre offices in the UK'
+text: 'Jobcentre offices in England, Scotland and Wales'


### PR DESCRIPTION
The jobcentre register applies to England, Scotland and Wales, but not Northern
Ireland.  Because this won't be explicit in the name (e.g.
`jobcentre-eng-sct-wls`), we will make it explicit in the register description.