### PR TITLE
Remove group field from jobcentre register

### DIFF
--- a/data/alpha/register/jobcentre.yaml
+++ b/data/alpha/register/jobcentre.yaml
@@ -1,7 +1,6 @@
 fields:
 - jobcentre
 - name
-- jobcentre-group
 - jobcentre-district
 - address
 - start-date

--- a/data/beta/register/jobcentre.yaml
+++ b/data/beta/register/jobcentre.yaml
@@ -1,7 +1,6 @@
 fields:
 - jobcentre
 - name
-- jobcentre-group
 - jobcentre-district
 - address
 - start-date


### PR DESCRIPTION
In both beta and alpha.  Agreed with custodian.  The hierarchy of group >
district > jobcentre is still preserved, now without duplication.