### PR TITLE
Add registry Ministry of Housing, Communities & Local Government and update registers

### DIFF
--- a/data/beta/register/local-authority-eng.yaml
+++ b/data/beta/register/local-authority-eng.yaml
@@ -7,5 +7,5 @@ fields:
 - "end-date"
 phase: "beta"
 register: "local-authority-eng"
-registry: "department-for-communities-and-local-government"
+registry: "ministry-of-housing-communities-and-local-government"
 text: "Local authorities in England"

--- a/data/beta/register/local-authority-type.yaml
+++ b/data/beta/register/local-authority-type.yaml
@@ -5,5 +5,5 @@ fields:
 - end-date
 phase: beta
 register: local-authority-type
-registry: department-for-communities-and-local-government
+registry: ministry-of-housing-communities-and-local-government
 text: Types of local government organisations in the UK

--- a/data/beta/registry/department-for-communities-and-local-government.yaml
+++ b/data/beta/registry/department-for-communities-and-local-government.yaml
@@ -1,1 +1,0 @@
-registry: department-for-communities-and-local-government

--- a/data/beta/registry/ministry-of-housing-communities-and-local-government.yaml
+++ b/data/beta/registry/ministry-of-housing-communities-and-local-government.yaml
@@ -1,0 +1,1 @@
+registry: ministry-of-housing-communities-and-local-government


### PR DESCRIPTION
This PR adds the new registry Ministry of Housing, Communities & Local Government (to replace DCLG) and updates `local-authority-eng` and `local-authority-type` registers to use this registry.