### PR TITLE
Make gov.uk lowercase in gov-domain register desc.

### DIFF
--- a/data/beta/register/government-domain.yaml
+++ b/data/beta/register/government-domain.yaml
@@ -7,4 +7,4 @@ fields:
 phase: beta
 register: government-domain
 registry: cabinet-office
-text: Government domains that appear on GOV.UK
+text: Government domains that appear on the gov.uk domain


### PR DESCRIPTION
Per custodian's request.  GOV.UK only means the website, whereas this register
covers everything on the gov.uk domain