### PR TITLE
Added the following register-definition files:

### DIFF
--- a/data/discovery/field/local-authority-sct.yaml
+++ b/data/discovery/field/local-authority-sct.yaml
@@ -1,0 +1,6 @@
+text: "A local authority in Scotland."
+field: "local-authority-sct"
+phase: "discovery"
+datatype: "string"
+register: "local-authority-sct"
+cardinality: "1"

--- a/data/discovery/field/school-phase-sct.yaml
+++ b/data/discovery/field/school-phase-sct.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-phase-sct
+phase: discovery
+register: school-phase-sct
+text: tbd

--- a/data/discovery/field/school-sct.yaml
+++ b/data/discovery/field/school-sct.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: school-sct
+phase: discovery
+register: school-sct
+text: A school in Scotland.

--- a/data/discovery/register/school-phase-sct.yaml
+++ b/data/discovery/register/school-phase-sct.yaml
@@ -1,0 +1,9 @@
+fields:
+- school-phase-sct
+- name
+- start-date
+- end-date
+phase: discovery
+register: school-phase-sct
+registry: cabinet-office
+text: tbd

--- a/data/discovery/register/school-sct.yaml
+++ b/data/discovery/register/school-sct.yaml
@@ -1,0 +1,12 @@
+fields:
+- school-sct
+- name
+- local-authority-sct
+- address
+- school-phase-sct
+- start-date
+- end-date
+phase: discovery
+register: school-sct
+registry: cabinet-office
+text: A register of schools in Scotland


### PR DESCRIPTION
- `register/school-sct.yaml`
- `register/school-phase.yaml`
- `field/school-sct.yaml`
- `field/school-phase.yaml`
- `field/local-authority-sct.yaml`*

Note - `local-authority-sct.yaml` failed the following test 'test_field_register_is_a_known_register[local-authority-sct]' due to register of 'local-authority-sct' not being defined in the deiscovery environment, however, the field is.

Please review