### PR TITLE
Isa person reg name change

### DIFF
--- a/data/discovery/field/information-sharing-agreement-person-0001.yaml
+++ b/data/discovery/field/information-sharing-agreement-person-0001.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: information-sharing-agreement-person-0001
-phase: discovery
-register: 'information-sharing-agreement-person-0001'
-text: The unique code for the information sharing agreement persons.

--- a/data/discovery/field/information-sharing-agreement-specified-person-0001.yaml
+++ b/data/discovery/field/information-sharing-agreement-specified-person-0001.yaml
@@ -1,0 +1,6 @@
+cardinality: '1'
+datatype: string
+field: information-sharing-agreement-specified-person-0001
+phase: discovery
+register: 'information-sharing-agreement-specified-person-0001'
+text: The unique code for the information sharing agreement specified persons.

--- a/data/discovery/register/information-sharing-agreement-specified-person-0001.yaml
+++ b/data/discovery/register/information-sharing-agreement-specified-person-0001.yaml
@@ -1,10 +1,10 @@
 fields:
-- information-sharing-agreement-person-0001
+- information-sharing-agreement-specified-person-0001
 - name
 - relevant-powers 
 - start-date
 - end-date
 phase: discovery
-register: information-sharing-agreement-person-0001
+register: information-sharing-agreement-specified-person-0001
 registry: department-for-digital-culture-media-sport
 text: Persons for the information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017

--- a/data/discovery/register/information-sharing-agreement-specified-person-0001.yaml
+++ b/data/discovery/register/information-sharing-agreement-specified-person-0001.yaml
@@ -7,4 +7,4 @@ fields:
 phase: discovery
 register: information-sharing-agreement-specified-person-0001
 registry: department-for-digital-culture-media-sport
-text: Persons for the information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017
+text: Specified persons for the information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017


### PR DESCRIPTION
A series of updates to the registry files for 'isa-person' register, to facilitate the update of the register name to 'isa-specified-person'.

The following has changed:
- updated the register yaml to replace all references of person to 'specified-person'.
- update the field yaml to replace all references of person to 'specified-person'.

