### PR TITLE
Delete CCG from alpha 

### DIFF
--- a/data/alpha/field/clinical-commissioning-group.yaml
+++ b/data/alpha/field/clinical-commissioning-group.yaml
@@ -1,6 +1,0 @@
-cardinality: '1'
-datatype: string
-field: clinical-commissioning-group
-phase: alpha
-register: clinical-commissioning-group
-text: The unique code assigned to the Clinical Commissioning Group.

--- a/data/alpha/register/clinical-commissioning-group.yaml
+++ b/data/alpha/register/clinical-commissioning-group.yaml
@@ -1,9 +1,0 @@
-fields:
-- clinical-commissioning-group
-- name
-- start-date
-- end-date
-phase: alpha
-register: clinical-commissioning-group
-registry: nhs-digital
-text: "Clinical Commissioning Groups in England"

--- a/data/alpha/registry/nhs-digital.yaml
+++ b/data/alpha/registry/nhs-digital.yaml
@@ -1,1 +1,0 @@
-registry: nhs-digital


### PR DESCRIPTION
Build was failing because clinical-commissioning-group existed in both alpha and beta directories.